### PR TITLE
Fix cache_mode = 'none' bugs and enable real-time search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Endpoint.nvim Development Makefile
 
-.PHONY: test test-symfony test-nestjs test-spring test-fastapi
+.PHONY: test test-symfony test-nestjs test-spring test-fastapi test-cache
 
 test:
 	nvim --headless --noplugin -u tests/minit.lua -c "PlenaryBustedDirectory tests/spec/"
@@ -16,3 +16,6 @@ test-spring:
 
 test-fastapi:
 	nvim --headless --noplugin -u tests/minit.lua -c "PlenaryBustedDirectory tests/spec/fastapi_spec.lua"
+
+test-cache:
+	nvim --headless --noplugin -u tests/minit.lua -c "PlenaryBustedDirectory tests/spec/cache_spec.lua"

--- a/lua/endpoint/services/batch_scan.lua
+++ b/lua/endpoint/services/batch_scan.lua
@@ -13,6 +13,11 @@ function M.scan_all_methods()
     return
   end
 
+  -- Clear temp table for real-time mode
+  if config.cache_mode == "none" then
+    cache.clear_temp_table()
+  end
+
   local framework_name = framework_manager.get_current_framework_name(config)
 
   if not framework_name then

--- a/lua/endpoint/services/cache.lua
+++ b/lua/endpoint/services/cache.lua
@@ -143,10 +143,21 @@ M.clear_temp_table = function()
   debug_log("clear_temp_table: temp_find_table cleared")
 end
 
+-- Ensure temp_find_table is initialized
+local function ensure_temp_table_initialized()
+  if not temp_find_table then
+    temp_find_table = {}
+  end
+end
+
 M.get_find_table = function()
   -- Check cache mode - if "none", return temp table
   local cache_config = get_cache_config()
   if cache_config.mode == "none" then
+    -- Ensure temp_find_table is initialized
+    if not temp_find_table then
+      temp_find_table = {}
+    end
     debug_log("get_find_table: cache_mode is none, returning temp table with entries: " .. tostring(vim.tbl_count(temp_find_table)))
     return temp_find_table
   end
@@ -233,6 +244,10 @@ M.create_find_table_entry = function(path, annotation)
   
   if cache_config.mode == "none" then
     debug_log("create_find_table_entry: cache_mode is none, using temp table")
+    -- Ensure temp_find_table is initialized
+    if not temp_find_table then
+      temp_find_table = {}
+    end
     -- Use temp table for real-time mode
     if not temp_find_table[path] then
       temp_find_table[path] = {}
@@ -260,6 +275,10 @@ M.insert_to_find_table = function(opts)
   
   if cache_config.mode == "none" then
     debug_log("insert_to_find_table: cache_mode is none, using temp table")
+    -- Ensure temp_find_table is initialized
+    if not temp_find_table then
+      temp_find_table = {}
+    end
     -- Use temp table for real-time mode
     table.insert(
       temp_find_table[opts.path][opts.annotation],
@@ -279,6 +298,10 @@ M.insert_to_find_request_table = function(opts)
   
   if cache_config.mode == "none" then
     debug_log("insert_to_find_request_table: cache_mode is none, using temp table")
+    -- Ensure temp_find_table is initialized
+    if not temp_find_table then
+      temp_find_table = {}
+    end
     -- Use temp table for real-time mode
     temp_find_table[opts.path][opts.annotation] = { value = opts.value, line_number = opts.line_number, column = opts.column }
     return

--- a/lua/endpoint/services/cache.lua
+++ b/lua/endpoint/services/cache.lua
@@ -137,6 +137,13 @@ M.clear_tables = function()
 end
 
 M.get_find_table = function()
+  -- Check cache mode - if "none", return empty table
+  local cache_config = get_cache_config()
+  if cache_config.mode == "none" then
+    debug_log("get_find_table: cache_mode is none, returning empty table")
+    return {}
+  end
+  
   ensure_cache_initialized()
   -- Track access for potential cleanup
   track_access("find_table", "global_access")
@@ -145,6 +152,13 @@ M.get_find_table = function()
 end
 
 M.get_preview_table = function()
+  -- Check cache mode - if "none", return empty table
+  local cache_config = get_cache_config()
+  if cache_config.mode == "none" then
+    debug_log("get_preview_table: cache_mode is none, returning empty table")
+    return {}
+  end
+  
   -- Track access for potential cleanup
   track_access("preview_table", "global_access")
   return preview_table
@@ -208,6 +222,13 @@ M.should_use_cache = function(key)
 end
 
 M.create_find_table_entry = function(path, annotation)
+  -- Don't create entries if cache mode is "none"
+  local cache_config = get_cache_config()
+  if cache_config.mode == "none" then
+    debug_log("create_find_table_entry: cache_mode is none, skipping")
+    return
+  end
+  
   if not find_table[path] then
     find_table[path] = {}
   end
@@ -221,6 +242,13 @@ M.create_find_table_entry = function(path, annotation)
 end
 
 M.insert_to_find_table = function(opts)
+  -- Don't insert if cache mode is "none"
+  local cache_config = get_cache_config()
+  if cache_config.mode == "none" then
+    debug_log("insert_to_find_table: cache_mode is none, skipping")
+    return
+  end
+  
   table.insert(
     find_table[opts.path][opts.annotation],
     { value = opts.value, line_number = opts.line_number, column = opts.column }
@@ -228,10 +256,24 @@ M.insert_to_find_table = function(opts)
 end
 
 M.insert_to_find_request_table = function(opts)
+  -- Don't insert if cache mode is "none"
+  local cache_config = get_cache_config()
+  if cache_config.mode == "none" then
+    debug_log("insert_to_find_request_table: cache_mode is none, skipping")
+    return
+  end
+  
   find_table[opts.path][opts.annotation] = { value = opts.value, line_number = opts.line_number, column = opts.column }
 end
 
 M.create_preview_entry = function(endpoint, path, line_number, column)
+  -- Don't create entries if cache mode is "none"
+  local cache_config = get_cache_config()
+  if cache_config.mode == "none" then
+    debug_log("create_preview_entry: cache_mode is none, skipping")
+    return
+  end
+  
   preview_table[endpoint] = {
     path = path,
     line_number = line_number,

--- a/lua/endpoint/services/util.lua
+++ b/lua/endpoint/services/util.lua
@@ -149,6 +149,11 @@ M.create_endpoint_table = function(method)
     return
   end
 
+  -- Clear temp table for real-time mode
+  if config.cache_mode == "none" then
+    cache.clear_temp_table()
+  end
+
   local framework_name = framework_manager.get_current_framework_name(config)
 
   if not framework_name then

--- a/lua/endpoint/services/util.lua
+++ b/lua/endpoint/services/util.lua
@@ -48,6 +48,13 @@ M.get_find_table = function()
 end
 
 M.create_endpoint_preview_table = function(method)
+  -- Clear temp table for real-time mode
+  local session = require "endpoint.core.session"
+  local config = session.get_config()
+  if config and config.cache_mode == "none" then
+    cache.clear_temp_table()
+  end
+  
   -- Get existing find_table (avoid rescanning)
   local find_table = cache.get_find_table()
 

--- a/tests/spec/cache_spec.lua
+++ b/tests/spec/cache_spec.lua
@@ -1,0 +1,244 @@
+describe("Cache system behavior", function()
+  local cache = require("endpoint.services.cache")
+  local endpoint = require("endpoint.services.endpoint")
+  
+  -- Mock data for testing
+  local mock_results = {
+    { value = "GET /api/users", method = "GET", path = "/api/users", file_path = "test.rb", line_number = 1 },
+    { value = "POST /api/users", method = "POST", path = "/api/users", file_path = "test.rb", line_number = 5 }
+  }
+  
+  -- Helper function to reset cache state
+  local function reset_cache()
+    cache.clear_tables()
+  end
+  
+  before_each(function()
+    reset_cache()
+  end)
+  
+  describe("cache mode: none", function()
+    local none_config = { cache_mode = "none" }
+    
+    it("should never return cached results", function()
+      local cache_key = "GET"
+      
+      -- Manually set some data in internal cache (simulating previous cached data)
+      cache.set_cached_results(cache_key, mock_results, { cache_mode = "session" })
+      
+      -- With "none" mode, should always return nil (no cache)
+      local cached = cache.get_cached_results(cache_key, none_config)
+      assert.is_nil(cached)
+    end)
+    
+    it("should never store cached results", function()
+      local cache_key = "POST"
+      
+      -- Try to cache results with "none" mode
+      cache.set_cached_results(cache_key, mock_results, none_config)
+      
+      -- Should not be cached, even with session mode retrieval
+      local cached = cache.get_cached_results(cache_key, { cache_mode = "session" })
+      assert.is_nil(cached)
+    end)
+    
+    it("should bypass cache completely in endpoint service", function()
+      -- Mock the create_endpoint_table function to track calls
+      local create_calls = 0
+      local original_create = endpoint.create_endpoint_table
+      endpoint.create_endpoint_table = function(method, config)
+        create_calls = create_calls + 1
+        return mock_results
+      end
+      
+      -- First call
+      local results1 = endpoint.get_endpoints("GET", none_config)
+      assert.are.equal(1, create_calls)
+      assert.are.same(mock_results, results1)
+      
+      -- Second call should also create new results (no cache)
+      local results2 = endpoint.get_endpoints("GET", none_config)
+      assert.are.equal(2, create_calls)
+      assert.are.same(mock_results, results2)
+      
+      -- Restore original function
+      endpoint.create_endpoint_table = original_create
+    end)
+  end)
+  
+  describe("cache mode: session", function()
+    local session_config = { cache_mode = "session" }
+    
+    it("should store and retrieve cached results", function()
+      local cache_key = "GET"
+      
+      -- Set cached results
+      cache.set_cached_results(cache_key, mock_results, session_config)
+      
+      -- Should retrieve cached results
+      local cached = cache.get_cached_results(cache_key, session_config)
+      assert.are.same(mock_results, cached)
+    end)
+    
+    it("should return nil when no cache exists", function()
+      local cache_key = "DELETE"
+      
+      -- No cached data exists
+      local cached = cache.get_cached_results(cache_key, session_config)
+      assert.is_nil(cached)
+    end)
+    
+    it("should use cache in endpoint service when available", function()
+      -- Mock the create_endpoint_table function
+      local create_calls = 0
+      local original_create = endpoint.create_endpoint_table
+      endpoint.create_endpoint_table = function(method, config)
+        create_calls = create_calls + 1
+        return mock_results
+      end
+      
+      -- Pre-populate cache
+      cache.set_cached_results("GET", mock_results, session_config)
+      cache.update_cache_timestamp("GET")
+      
+      -- First call should use cache (no create call)
+      local results1 = endpoint.get_endpoints("GET", session_config)
+      assert.are.equal(0, create_calls)
+      assert.are.same(mock_results, results1)
+      
+      -- Clear cache and call again
+      reset_cache()
+      local results2 = endpoint.get_endpoints("GET", session_config)
+      assert.are.equal(1, create_calls)
+      assert.are.same(mock_results, results2)
+      
+      -- Restore original function
+      endpoint.create_endpoint_table = original_create
+    end)
+  end)
+  
+  describe("cache mode: persistent", function()
+    local persistent_config = { cache_mode = "persistent" }
+    
+    it("should store and retrieve cached results", function()
+      local cache_key = "PUT"
+      
+      -- Set cached results
+      cache.set_cached_results(cache_key, mock_results, persistent_config)
+      
+      -- Should retrieve cached results
+      local cached = cache.get_cached_results(cache_key, persistent_config)
+      assert.are.same(mock_results, cached)
+    end)
+    
+    it("should handle cache validation correctly", function()
+      local cache_key = "PATCH"
+      
+      -- Set cached results with timestamp
+      cache.set_cached_results(cache_key, mock_results, persistent_config)
+      cache.update_cache_timestamp(cache_key)
+      
+      -- Should be valid cache
+      local is_valid = cache.is_cache_valid(cache_key)
+      assert.is_true(is_valid)
+      
+      -- Should use cache
+      local should_use = cache.should_use_cache(cache_key)
+      assert.is_true(should_use)
+    end)
+  end)
+  
+  describe("cache mode transitions", function()
+    it("should handle switching between different cache modes", function()
+      local cache_key = "GET"
+      
+      -- Start with session cache
+      cache.set_cached_results(cache_key, mock_results, { cache_mode = "session" })
+      local cached_session = cache.get_cached_results(cache_key, { cache_mode = "session" })
+      assert.are.same(mock_results, cached_session)
+      
+      -- Switch to "none" mode - should return nil
+      local cached_none = cache.get_cached_results(cache_key, { cache_mode = "none" })
+      assert.is_nil(cached_none)
+      
+      -- Switch to persistent mode - should still have data (if valid)
+      cache.update_cache_timestamp(cache_key)
+      local cached_persistent = cache.get_cached_results(cache_key, { cache_mode = "persistent" })
+      assert.are.same(mock_results, cached_persistent)
+    end)
+  end)
+  
+  describe("cache interface", function()
+    it("should have consistent get_cached_results behavior", function()
+      local cache_key = "TEST"
+      
+      -- Test with nil config (should use default)
+      local cached_nil = cache.get_cached_results(cache_key, nil)
+      assert.is_nil(cached_nil) -- No cache exists yet
+      
+      -- Test with empty config
+      local cached_empty = cache.get_cached_results(cache_key, {})
+      assert.is_nil(cached_empty)
+    end)
+    
+    it("should have consistent set_cached_results behavior", function()
+      local cache_key = "TEST"
+      
+      -- Should not error with nil config
+      assert.has_no_error(function()
+        cache.set_cached_results(cache_key, mock_results, nil)
+      end)
+      
+      -- Should not error with empty config
+      assert.has_no_error(function()
+        cache.set_cached_results(cache_key, mock_results, {})
+      end)
+    end)
+  end)
+  
+  describe("cache clear operations", function()
+    it("should clear all cache data correctly", function()
+      -- Populate cache with different modes
+      cache.set_cached_results("GET", mock_results, { cache_mode = "session" })
+      cache.set_cached_results("POST", mock_results, { cache_mode = "persistent" })
+      cache.update_cache_timestamp("GET")
+      cache.update_cache_timestamp("POST")
+      
+      -- Verify data exists
+      local cached_get = cache.get_cached_results("GET", { cache_mode = "session" })
+      local cached_post = cache.get_cached_results("POST", { cache_mode = "persistent" })
+      assert.are.same(mock_results, cached_get)
+      assert.are.same(mock_results, cached_post)
+      
+      -- Clear cache
+      cache.clear_tables()
+      
+      -- Verify data is cleared
+      local cleared_get = cache.get_cached_results("GET", { cache_mode = "session" })
+      local cleared_post = cache.get_cached_results("POST", { cache_mode = "persistent" })
+      assert.is_nil(cleared_get)
+      assert.is_nil(cleared_post)
+    end)
+  end)
+  
+  describe("default cache mode behavior", function()
+    it("should use default cache mode when not specified", function()
+      local default_config = require("endpoint.core.config")
+      
+      -- Default should be "none"
+      assert.are.equal("none", default_config.cache_mode)
+    end)
+    
+    it("should handle fallback cache mode correctly", function()
+      -- Test session fallback behavior
+      local session = require("endpoint.core.session")
+      
+      -- Should use fallback logic (implementation depends on session.lua)
+      assert.has_no_error(function()
+        local cache_config = session.get_config()
+        -- Session config can be nil if not initialized, which is valid
+        -- The important thing is that it doesn't error
+      end)
+    end)
+  end)
+end)


### PR DESCRIPTION
## Summary
- Fixed cache_mode = 'none' not displaying results in telescope finder
- Fixed preview data not found errors in real-time mode
- Fixed deleted files remaining in find table after deletion
- Added comprehensive temp table system for real-time search

## Changes Made
### Core Fixes
- Added `temp_find_table` and `temp_preview_table` for real-time mode storage
- Modified `get_find_table()` and `get_preview_table()` to return temp tables in 'none' mode
- Updated all cache functions to use temp tables when `cache_mode = 'none'`
- Added proper nil checks to prevent "expected table, got nil" errors

### Search Behavior
- `create_endpoint_table()`, `create_endpoint_preview_table()`, and `batch_scan()` now clear temp tables
- Ensures deleted files are removed from next search in real-time mode
- Preview data now works correctly in real-time mode

## Test Plan
- [x] Test telescope finder displays results with `cache_mode = 'none'`  
- [x] Test preview data works in real-time mode
- [x] Test deleted files disappear from next search
- [x] Test no nil table errors occur
- [x] Test session and persistent cache modes still work

## Files Modified
- `lua/endpoint/services/cache.lua` - Core temp table implementation
- `lua/endpoint/services/util.lua` - Temp table clearing in search functions  
- `lua/endpoint/services/batch_scan.lua` - Temp table clearing in batch scan

This ensures `cache_mode = 'none'` provides true real-time search behavior without cache-related confusion.