### PR TITLE
  feat: implement comprehensive Symfony multiline annotation support

### DIFF
--- a/meta/types.lua
+++ b/meta/types.lua
@@ -202,6 +202,7 @@
 ---@field get_method_text fun(self: endpoint.Themes, method: string, config: table): string
 
 ---@class endpoint.SymfonyParser : endpoint.Parser
+---@field private _last_end_line_number number|nil
 ---@field private _read_file_lines fun(self: endpoint.SymfonyParser, file_path: string, line_number: number): string[]|nil
 ---@field private _find_controller_level_route fun(self: endpoint.SymfonyParser, lines: string[], line_number: number): string
 ---@field private _extract_controller_route_path fun(self: endpoint.SymfonyParser, annotation_line: string): string|nil
@@ -209,9 +210,14 @@
 ---@field private _extract_path_from_php8_attributes fun(self: endpoint.SymfonyParser, content: string): string|nil
 ---@field private _extract_path_from_annotations fun(self: endpoint.SymfonyParser, content: string): string|nil
 ---@field private _extract_path_from_docblock fun(self: endpoint.SymfonyParser, content: string): string|nil
+---@field private _extract_path_single_line fun(self: endpoint.SymfonyParser, content: string): string|nil
+---@field private _extract_path_multiline fun(self: endpoint.SymfonyParser, file_path: string, start_line: number, content: string): string|nil, number|nil
+---@field private _is_multiline_annotation fun(self: endpoint.SymfonyParser, content: string): boolean
+---@field private _extract_methods_multiline fun(self: endpoint.SymfonyParser, content: string, file_path: string, line_number: number): string[]
 ---@field private _extract_methods_from_annotation fun(self: endpoint.SymfonyParser, content: string): string[]
 ---@field private _combine_paths fun(self: endpoint.SymfonyParser, base?: string, endpoint?: string): string
 ---@field private _detect_annotation_type fun(self: endpoint.SymfonyParser, content: string): string
+---@field private _calculate_annotation_column fun(self: endpoint.SymfonyParser, content: string, file_path: string, line_number: number, ripgrep_column: number): number
 ---@field private _is_symfony_route_content fun(self: endpoint.SymfonyParser, content: string): boolean
 
 ---@class endpoint.ExpressParser : endpoint.Parser


### PR DESCRIPTION
  Summary

  - Implement full multiline annotation parsing for Symfony PHP 8+ attributes and legacy docblock annotations
  - Add accurate highlighting support with proper start/end line detection
  - Support multiple HTTP methods per annotation (creates separate endpoints)
  - Fix column positioning issues in multiline mode

  Key Features

  - Multiline Path Extraction: _extract_path_multiline() reads across file lines to parse complete annotations
  - Multiline Method Detection: _extract_methods_multiline() handles methods defined across multiple lines
  - Annotation Boundary Detection: _is_multiline_annotation() identifies incomplete annotations that span lines
  - Accurate Column Calculation: _calculate_annotation_column() fixes ripgrep multiline column=1 issue
  - End Line Tracking: end_line_number support for precise highlighting ranges

  Supported Patterns

```php
  // Simple multiline
  #[Route(
      '/users/{id}',
      methods: ['GET']
  )]

  // Complex multiline with multiple methods
  #[Route(
      '/secure/users/{id}',
      methods: ['GET', 'PUT', 'DELETE'],
      requirements: ['id' => '\d+']
  )]

  // Legacy docblock multiline
  /**
   * @Route(
   *     "/legacy/users/{id}",
   *     methods={"GET"},
   *     requirements={"id"="\d+"}
   * )
   */
```

  Test Plan

  - Test multiline PHP 8+ attributes
  - Test legacy docblock annotations
  - Test multiple HTTP methods per annotation
  - Test highlighting accuracy (start/end positions)
  - Test column positioning fixes

  🤖 Generated with https://claude.ai/code
