### PR TITLE
feat: Improve endpoint duplicate filtering for monorepo and microservice support

### DIFF
--- a/lua/endpoint/core/Framework.lua
+++ b/lua/endpoint/core/Framework.lua
@@ -256,12 +256,16 @@ end
 
 ---Post-processes endpoints to remove duplicates and clean up
 function Framework:_post_process_endpoints(endpoints)
-  -- Remove duplicates based on method + path only (ignore file/line differences)
+  -- Remove duplicates based on method + path + file (preserve endpoints from different files)
   local seen = {}
   local unique_endpoints = {}
 
   for _, endpoint in ipairs(endpoints) do
-    local key = string.format("%s:%s", endpoint.method or "", endpoint.endpoint_path or "")
+    local key = string.format("%s:%s:%s",
+      endpoint.method or "",
+      endpoint.endpoint_path or "",
+      endpoint.file_path or ""
+    )
 
     if not seen[key] then
       seen[key] = true


### PR DESCRIPTION
  ## Summary
  Enhances the duplicate endpoint filtering logic to better support monorepo and microservice architectures by changing the deduplication criteria from `method + path` to `method + path + file`.

  ## Problem
  The current duplicate filtering was too aggressive and caused issues in complex project structures:

  ```lua
  -- Current behavior (problematic):
  service-a/user_controller.py  → GET /api/users (user management)
  service-b/auth_controller.py  → GET /api/users (authenticated users)
  service-c/admin_controller.py → GET /api/users (admin user list)


  Result: Only the first endpoint was kept, losing visibility into other services ❌

  Solution

  Changed duplicate detection key from method:path to method:path:file:


  Before:
  local key = string.format("%s:%s", endpoint.method or "", endpoint.endpoint_path or "")
  -- Example: "GET:/api/users" (same for all files)

  After:
  local key = string.format("%s:%s:%s",
    endpoint.method or "",
    endpoint.endpoint_path or "",
    endpoint.file_path or ""
  )
  -- Example: "GET:/api/users:/path/to/service-a/user_controller.py"
```

  Benefits

  ✅ Monorepo Support

  - Same API path across different services/modules are now all visible
  - Each service's endpoints are preserved individually
  - Better navigation in complex project structures

  ✅ Microservice Architecture

  - Multiple services with overlapping API paths work correctly
  - Developers can see all implementations of similar endpoints
  - No accidental filtering of legitimate endpoints

  ✅ True Duplicate Removal

  - Still removes actual duplicates (e.g., parsing artifacts from same file/line)
  - Only eliminates redundant entries within the same file
  - Preserves all meaningful endpoint variations

  Use Cases

  Monorepo Example:
  apps/
  ├── user-service/controllers/users.py     → GET /api/users
  ├── admin-service/controllers/users.py    → GET /api/users
  └── billing-service/controllers/users.py  → GET /api/users
  All three endpoints now appear in results 🎯

  Legacy Code Example:
  controllers/
  ├── v1/users_controller.php → GET /api/users
  └── v2/users_controller.php → GET /api/users
  Both API versions are visible 🎯

  Files Changed

  - lua/endpoint/core/Framework.lua - Updated _post_process_endpoints() method

  Breaking Changes

  None. This is a purely additive improvement that increases visibility.

  Testing

  - ✅ Tested with monorepo structure
  - ✅ Verified true duplicates still removed
  - ✅ Confirmed different files with same endpoints preserved
