### PR TITLE
  feat: add Maven multi-module project detection support

### DIFF
--- a/meta/types.lua
+++ b/meta/types.lua
@@ -137,6 +137,8 @@
 ---@field add_manifest_files fun(self: endpoint.Detector, additional_manifest_files: string[])
 ---@field get_required_dependencies fun(self: endpoint.Detector): string[]
 ---@field get_manifest_files fun(self: endpoint.Detector): string[]
+---@field _should_check_submodules fun(self: endpoint.Detector): boolean
+---@field _find_submodule_manifest_files fun(self: endpoint.Detector): string[]
 
 
 -- Parsing Pattern

--- a/tests/fixtures/spring-multi-module/common/pom.xml
+++ b/tests/fixtures/spring-multi-module/common/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>multi-module-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>common</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Common Module</name>
+    <description>Common utilities and shared components</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>5.3.21</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/tests/fixtures/spring-multi-module/order-service/.classpath
+++ b/tests/fixtures/spring-multi-module/order-service/.classpath
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="src" output="target/classes" path="src/main/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="src/test/java">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry excluding="**" kind="src" output="target/test-classes" path="src/test/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="test" value="true"/>
+			<attribute name="optional" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.m2e.MAVEN2_CLASSPATH_CONTAINER">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" path="target/generated-sources/annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="src" output="target/test-classes" path="target/generated-test-sources/test-annotations">
+		<attributes>
+			<attribute name="optional" value="true"/>
+			<attribute name="maven.pomderived" value="true"/>
+			<attribute name="ignore_optional_problems" value="true"/>
+			<attribute name="m2e-apt" value="true"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/tests/fixtures/spring-multi-module/order-service/.project
+++ b/tests/fixtures/spring-multi-module/order-service/.project
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>order-service</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1758844213575</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.core.resources.prefs
+++ b/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding/<project>=UTF-8

--- a/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.jdt.apt.core.prefs
+++ b/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.jdt.apt.core.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.apt.aptEnabled=false

--- a/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.jdt.core.prefs
+++ b/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,9 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=11
+org.eclipse.jdt.core.compiler.compliance=11
+org.eclipse.jdt.core.compiler.problem.enablePreviewFeatures=disabled
+org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
+org.eclipse.jdt.core.compiler.problem.reportPreviewFeatures=ignore
+org.eclipse.jdt.core.compiler.processAnnotations=disabled
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=11

--- a/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.m2e.core.prefs
+++ b/tests/fixtures/spring-multi-module/order-service/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/tests/fixtures/spring-multi-module/order-service/pom.xml
+++ b/tests/fixtures/spring-multi-module/order-service/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>multi-module-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>order-service</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Order Service</name>
+    <description>Order processing microservice</description>
+
+    <properties>
+        <spring-boot.version>2.7.2</spring-boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>common</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/fixtures/spring-multi-module/order-service/src/main/java/com/example/order/Order.java
+++ b/tests/fixtures/spring-multi-module/order-service/src/main/java/com/example/order/Order.java
@@ -1,0 +1,50 @@
+package com.example.order;
+
+public class Order {
+    private Long id;
+    private Long userId;
+    private String productName;
+    private Double amount;
+
+    public Order() {
+    }
+
+    public Order(Long id, Long userId, String productName, Double amount) {
+        this.id = id;
+        this.userId = userId;
+        this.productName = productName;
+        this.amount = amount;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
+
+    public String getProductName() {
+        return productName;
+    }
+
+    public void setProductName(String productName) {
+        this.productName = productName;
+    }
+
+    public Double getAmount() {
+        return amount;
+    }
+
+    public void setAmount(Double amount) {
+        this.amount = amount;
+    }
+}

--- a/tests/fixtures/spring-multi-module/order-service/src/main/java/com/example/order/OrderController.java
+++ b/tests/fixtures/spring-multi-module/order-service/src/main/java/com/example/order/OrderController.java
@@ -1,0 +1,53 @@
+package com.example.order;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    @GetMapping
+    public List<Order> getAllOrders() {
+        List<Order> orders = new ArrayList<>();
+        orders.add(new Order(1L, 1L, "Electronics", 299.99));
+        orders.add(new Order(2L, 2L, "Books", 49.99));
+        return orders;
+    }
+
+    @GetMapping("/{id}")
+    public Order getOrderById(@PathVariable Long id) {
+        return new Order(id, 1L, "Product " + id, 99.99);
+    }
+
+    @PostMapping
+    public Order createOrder(@RequestBody Order order) {
+        order.setId(System.currentTimeMillis());
+        return order;
+    }
+
+    @PutMapping("/{id}")
+    public Order updateOrder(@PathVariable Long id, @RequestBody Order order) {
+        order.setId(id);
+        return order;
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteOrder(@PathVariable Long id) {
+        // Delete logic
+    }
+
+    @GetMapping("/user/{userId}")
+    public List<Order> getOrdersByUserId(@PathVariable Long userId) {
+        List<Order> orders = new ArrayList<>();
+        orders.add(new Order(1L, userId, "User Order", 199.99));
+        return orders;
+    }
+
+    @PostMapping("/{id}/cancel")
+    public Order cancelOrder(@PathVariable Long id) {
+        return new Order(id, 1L, "Cancelled Order", 0.0);
+    }
+}

--- a/tests/fixtures/spring-multi-module/pom.xml
+++ b/tests/fixtures/spring-multi-module/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>multi-module-parent</artifactId>
+    <version>1.0.0</version>
+    <packaging>pom</packaging>
+
+    <name>Multi Module Parent</name>
+    <description>Parent POM for multi-module Spring Boot project</description>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <modules>
+        <module>common</module>
+        <module>user-service</module>
+        <module>order-service</module>
+    </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/fixtures/spring-multi-module/user-service/pom.xml
+++ b/tests/fixtures/spring-multi-module/user-service/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.example</groupId>
+        <artifactId>multi-module-parent</artifactId>
+        <version>1.0.0</version>
+    </parent>
+
+    <artifactId>user-service</artifactId>
+    <packaging>jar</packaging>
+
+    <name>User Service</name>
+    <description>User management microservice</description>
+
+    <properties>
+        <spring-boot.version>2.7.2</spring-boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring-boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.example</groupId>
+            <artifactId>common</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring-boot.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tests/fixtures/spring-multi-module/user-service/src/main/java/com/example/user/User.java
+++ b/tests/fixtures/spring-multi-module/user-service/src/main/java/com/example/user/User.java
@@ -1,0 +1,40 @@
+package com.example.user;
+
+public class User {
+    private Long id;
+    private String email;
+    private String name;
+
+    public User() {
+    }
+
+    public User(Long id, String email, String name) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/tests/fixtures/spring-multi-module/user-service/src/main/java/com/example/user/UserController.java
+++ b/tests/fixtures/spring-multi-module/user-service/src/main/java/com/example/user/UserController.java
@@ -1,0 +1,48 @@
+package com.example.user;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/users")
+public class UserController {
+
+    @GetMapping
+    public List<User> getAllUsers() {
+        List<User> users = new ArrayList<>();
+        users.add(new User(1L, "john@example.com", "John Doe"));
+        users.add(new User(2L, "jane@example.com", "Jane Smith"));
+        return users;
+    }
+
+    @GetMapping("/{id}")
+    public User getUserById(@PathVariable Long id) {
+        return new User(id, "user" + id + "@example.com", "User " + id);
+    }
+
+    @PostMapping
+    public User createUser(@RequestBody User user) {
+        user.setId(System.currentTimeMillis());
+        return user;
+    }
+
+    @PutMapping("/{id}")
+    public User updateUser(@PathVariable Long id, @RequestBody User user) {
+        user.setId(id);
+        return user;
+    }
+
+    @DeleteMapping("/{id}")
+    public void deleteUser(@PathVariable Long id) {
+        // Delete logic
+    }
+
+    @GetMapping("/search")
+    public List<User> searchUsers(@RequestParam String query) {
+        List<User> users = new ArrayList<>();
+        users.add(new User(1L, query + "@example.com", "Found User"));
+        return users;
+    }
+}


### PR DESCRIPTION
  ## Summary
  - Add support for detecting Spring Boot dependencies in Maven multi-module projects
  - Enhance Detector to check submodule pom.xml files when root pom.xml doesn't contain Spring dependencies
  - Improve test coverage with proper mocking infrastructure

  ## Changes
  - **lua/endpoint/core/Detector.lua**:
    - Add `_should_check_submodules()` method to determine if submodule checking is needed
    - Add `_find_submodule_manifest_files()` method to discover submodule pom.xml files
    - Enhance `is_target_detected()` to check both root and submodule manifest files
  - **tests/spec/spring_spec.lua**: 
    - Add comprehensive test coverage for Maven project detection
    - Implement `mockFs` helper function for cleaner test setup
    - Add proper mocking and cleanup infrastructure
  - **meta/types.lua**: Update type annotations for new detector methods

  ## Features Added
  - **Multi-module Detection**: Automatically detects Spring Boot dependencies in Maven submodules
  - **Submodule Discovery**: Uses `vim.fn.glob("*/pom.xml")` to find all submodule pom.xml files
  - **Hierarchical Checking**: First checks root pom.xml, then falls back to submodule checking

  ## Test Improvements
  - Added `mockFs(has_pom, has_spring_deps)` helper for consistent test mocking
  - Proper function backup/restore to prevent test interference
  - Comprehensive coverage for both positive and negative detection scenarios

  ## Use Case
  This enhancement allows endpoint.nvim to properly detect Spring Boot projects in Maven multi-module setups where:
  - Root pom.xml exists but contains no Spring dependencies
  - Spring Boot dependencies are defined in individual submodule pom.xml files
