### PR TITLE
fix: resolve NestJS GraphQL decorator parsing issue

### DIFF
--- a/lua/endpoint/parser/nestjs_parser.lua
+++ b/lua/endpoint/parser/nestjs_parser.lua
@@ -412,6 +412,12 @@ function NestJsParser:_looks_like_incomplete_decorator(content)
     end
   end
 
+  -- Special case for GraphQL decorators: @Query(() => Type) or @Mutation(() => Type)
+  -- These need extended content to find the function name
+  if self:_is_graphql_decorator(content) and content:match "^%s*@%w+%s*%(.-%)%s*$" then
+    return true
+  end
+
   -- Special case for decorators that don't close properly
   -- Count parentheses to see if they're balanced
   local open_count = 0

--- a/tests/spec/nestjs_spec.lua
+++ b/tests/spec/nestjs_spec.lua
@@ -179,6 +179,26 @@ async createNewUser(
         assert.equals("createUser", result.endpoint_path)
       end
     end)
+
+    it("should parse @Query without options on same line", function()
+      local content = '@Query(() => [SomeDto])\n  async getSomething(): Promise<SomeDto[]> {'
+      local result = parser:parse_content(content, "users.resolver.ts", 1, 1)
+
+      if result then
+        assert.equals("QUERY", result.method)
+        assert.equals("getSomething", result.endpoint_path)
+      end
+    end)
+
+    it("should parse @Query with options starting on same line", function()
+      local content = '@Query(() => [SomeDto], {\n    nullable: true,\n  })\n  async getSomething(): Promise<SomeDto[]> {'
+      local result = parser:parse_content(content, "users.resolver.ts", 1, 1)
+
+      if result then
+        assert.equals("QUERY", result.method)
+        assert.equals("getSomething", result.endpoint_path)
+      end
+    end)
   end)
 
   describe("Search Command Generation", function()


### PR DESCRIPTION
Fix bug where @Query/@Mutation decorators without options object were not being detected:
- @Query(() => [Type]) now works correctly
- @Mutation(() => Type) now works correctly

The issue was that decorators ending with ')' were incorrectly identified as "decorator only" and returning nil. Now they are treated as incomplete decorators that need extended content to find the function name.

Add test cases for both patterns:
- @Query without options on same line
- @Query with options starting on same line