### PR TITLE
fix: resolve Windows path parsing issue in ripgrep results

### DIFF
--- a/lua/endpoint/core/Framework.lua
+++ b/lua/endpoint/core/Framework.lua
@@ -202,15 +202,18 @@ function Framework:_parse_result_line(result_line)
     return {}
   end
 
-  -- Parse ripgrep output format: file:line:col:content
-  local source_file_path, source_line_number, source_column_position, line_content =
-    result_line:match "([^:]+):(%d+):(%d+):(.*)"
-  if not source_file_path or not source_line_number or not source_column_position or not line_content then
+  -- Use rg util to parse result line (handles Windows and Unix paths)
+  local rg_util = require "endpoint.utils.rg"
+  local parsed = rg_util.parse_result_line(result_line)
+
+  if not parsed then
     return {}
   end
 
-  local line_num = tonumber(source_line_number) or 1
-  local col_pos = tonumber(source_column_position) or 1
+  local source_file_path = parsed.file_path
+  local line_num = parsed.line_number
+  local col_pos = parsed.column
+  local line_content = parsed.content
 
   local endpoints = {}
   if self.parser then

--- a/lua/endpoint/utils/rg.lua
+++ b/lua/endpoint/utils/rg.lua
@@ -68,4 +68,39 @@ M.common_file_patterns = {
   react = { "**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx" },
 }
 
+-- Parse ripgrep result line into components
+-- Handles both Unix and Windows paths
+-- Format: file:line:col:content
+function M.parse_result_line(result_line)
+  if not result_line or result_line == "" then
+    return nil
+  end
+
+  -- Try to parse ripgrep output: file:line:col:content
+  -- Need to handle Windows paths like C:\path\file.java:10:5:content
+  -- And Unix paths like /path/file.java:10:5:content
+
+  -- Match pattern that handles Windows drive letters (C:) and Unix paths
+  local file_path, line_number, column, content
+
+  -- Try Windows path first (C:\...:line:col:content)
+  if result_line:match "^[A-Z]:" then
+    file_path, line_number, column, content = result_line:match "^([A-Z]:[^:]+):(%d+):(%d+):(.*)$"
+  else
+    -- Unix path (/...:line:col:content)
+    file_path, line_number, column, content = result_line:match "^([^:]+):(%d+):(%d+):(.*)$"
+  end
+
+  if not file_path or not line_number or not column or not content then
+    return nil
+  end
+
+  return {
+    file_path = file_path,
+    line_number = tonumber(line_number),
+    column = tonumber(column),
+    content = content,
+  }
+end
+
 return M

--- a/tests/spec/rg_util_spec.lua
+++ b/tests/spec/rg_util_spec.lua
@@ -1,0 +1,86 @@
+local rg_util = require "endpoint.utils.rg"
+
+describe("Ripgrep Utility", function()
+  describe("parse_result_line", function()
+    it("should parse Unix path correctly", function()
+      local line = "/home/user/project/src/Controller.java:10:5:@GetMapping"
+      local result = rg_util.parse_result_line(line)
+
+      assert.is_not_nil(result)
+      assert.equals("/home/user/project/src/Controller.java", result.file_path)
+      assert.equals(10, result.line_number)
+      assert.equals(5, result.column)
+      assert.equals("@GetMapping", result.content)
+    end)
+
+    it("should parse Windows path correctly", function()
+      local line = "C:\\Users\\user\\project\\src\\Controller.java:10:5:@GetMapping"
+      local result = rg_util.parse_result_line(line)
+
+      assert.is_not_nil(result)
+      assert.equals("C:\\Users\\user\\project\\src\\Controller.java", result.file_path)
+      assert.equals(10, result.line_number)
+      assert.equals(5, result.column)
+      assert.equals("@GetMapping", result.content)
+    end)
+
+    it("should parse Windows path with forward slashes", function()
+      local line = "C:/Users/user/project/src/Controller.java:10:5:@GetMapping"
+      local result = rg_util.parse_result_line(line)
+
+      assert.is_not_nil(result)
+      assert.equals("C:/Users/user/project/src/Controller.java", result.file_path)
+      assert.equals(10, result.line_number)
+      assert.equals(5, result.column)
+      assert.equals("@GetMapping", result.content)
+    end)
+
+    it("should handle content with colons", function()
+      local line = "/path/to/file.ts:15:8:@Query(() => User, { name: 'user' })"
+      local result = rg_util.parse_result_line(line)
+
+      assert.is_not_nil(result)
+      assert.equals("/path/to/file.ts", result.file_path)
+      assert.equals(15, result.line_number)
+      assert.equals(8, result.column)
+      assert.equals("@Query(() => User, { name: 'user' })", result.content)
+    end)
+
+    it("should handle Windows path with content containing colons", function()
+      local line = "D:\\project\\app\\resolver.ts:20:10:@Mutation(() => User, { description: 'test' })"
+      local result = rg_util.parse_result_line(line)
+
+      assert.is_not_nil(result)
+      assert.equals("D:\\project\\app\\resolver.ts", result.file_path)
+      assert.equals(20, result.line_number)
+      assert.equals(10, result.column)
+      assert.equals("@Mutation(() => User, { description: 'test' })", result.content)
+    end)
+
+    it("should return nil for empty line", function()
+      local result = rg_util.parse_result_line("")
+      assert.is_nil(result)
+    end)
+
+    it("should return nil for nil input", function()
+      local result = rg_util.parse_result_line(nil)
+      assert.is_nil(result)
+    end)
+
+    it("should return nil for malformed line", function()
+      local result = rg_util.parse_result_line("invalid line format")
+      assert.is_nil(result)
+    end)
+
+    it("should handle relative paths", function()
+      local line = "src/controllers/user.controller.ts:25:3:@Get('/users')"
+      local result = rg_util.parse_result_line(line)
+
+      assert.is_not_nil(result)
+      assert.equals("src/controllers/user.controller.ts", result.file_path)
+      assert.equals(25, result.line_number)
+      assert.equals(3, result.column)
+      assert.equals("@Get('/users')", result.content)
+    end)
+  end)
+end)


### PR DESCRIPTION
Fix bug where Windows file paths with drive letters (C:\path\file.java) were not being parsed correctly from ripgrep output.

Changes:
- Add parse_result_line() function to utils/rg.lua to handle both Windows (C:\...) and Unix (/...) path formats
- Update Framework._parse_result_line() to use centralized parser
- Add comprehensive test coverage for various path formats

This fixes the issue reported by Reddit user adelarsq where Spring projects on Windows were returning no results despite ripgrep finding matches when run directly in PowerShell.

Test cases cover:
- Unix absolute paths
- Windows paths with backslashes
- Windows paths with forward slashes
- Paths with colons in content
- Relative paths